### PR TITLE
Sort the contacts when called GetAll

### DIFF
--- a/internal/service/contacts/service_test.go
+++ b/internal/service/contacts/service_test.go
@@ -6,8 +6,11 @@ import (
 	"testing"
 	"time"
 
+	stdlanguage "golang.org/x/text/language"
+
 	"github.com/Peltoche/gnocchi/internal/tools"
 	"github.com/Peltoche/gnocchi/internal/tools/errs"
+	"github.com/Peltoche/gnocchi/internal/tools/language"
 	"github.com/Peltoche/gnocchi/internal/tools/sqlstorage"
 	"github.com/Peltoche/gnocchi/internal/tools/uuid"
 	"github.com/stretchr/testify/assert"
@@ -81,6 +84,7 @@ func Test_Contacts_Service(t *testing.T) {
 	t.Run("GetAll success", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
+		ctx = language.SetBrowserLangFromReq(ctx, stdlanguage.English)
 
 		tools := tools.NewMock(t)
 		storage := newMockStorage(t)
@@ -106,6 +110,7 @@ func Test_Contacts_Service(t *testing.T) {
 	t.Run("GetAll with a storage error", func(t *testing.T) {
 		t.Parallel()
 		ctx := context.Background()
+		ctx = language.SetBrowserLangFromReq(ctx, stdlanguage.English)
 
 		tools := tools.NewMock(t)
 		storage := newMockStorage(t)

--- a/internal/tools/language/http_handler.go
+++ b/internal/tools/language/http_handler.go
@@ -1,0 +1,53 @@
+package language
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/Peltoche/gnocchi/internal/tools/logger"
+	"golang.org/x/text/language"
+)
+
+var browserLangCtxKey = &contextKey{"accept-language"}
+
+func Middleware(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		browserLanguage := language.English
+
+		browserLanguages, _, err := language.ParseAcceptLanguage(r.Header.Get("Accept-Language"))
+		if err != nil {
+			logger.LogEntrySetError(r.Context(), fmt.Errorf("failed to parse the accept-lanuage header: %w", err))
+			// Set the default language
+		}
+
+		if len(browserLanguages) > 0 {
+			browserLanguage = browserLanguages[0]
+		}
+
+		ctx := context.WithValue(r.Context(), browserLangCtxKey, browserLanguage)
+
+		next.ServeHTTP(w, r.WithContext(ctx))
+	}
+
+	return http.HandlerFunc(fn)
+}
+
+func SetBrowserLangFromReq(ctx context.Context, tag language.Tag) context.Context {
+	return context.WithValue(ctx, browserLangCtxKey, tag)
+}
+
+func GetBrowserLangFromReq(ctx context.Context) language.Tag {
+	return ctx.Value(browserLangCtxKey).(language.Tag)
+}
+
+// contextKey is a value for use with context.WithValue. It's used as
+// a pointer so it fits in an interface{} without allocation. This technique
+// for defining context keys was copied from Go 1.7's new use of context in net/http.
+type contextKey struct {
+	name string
+}
+
+func (k *contextKey) String() string {
+	return "tools/language context value " + k.name
+}

--- a/internal/tools/router/middlewares.go
+++ b/internal/tools/router/middlewares.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 
 	"github.com/Peltoche/gnocchi/internal/tools"
+	"github.com/Peltoche/gnocchi/internal/tools/language"
 	"github.com/Peltoche/gnocchi/internal/tools/logger"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
@@ -16,6 +17,7 @@ import (
 type Middleware func(next http.Handler) http.Handler
 
 type Middlewares struct {
+	BrowserLang  Middleware
 	StripSlashed Middleware
 	Logger       Middleware
 	OnlyJSON     Middleware
@@ -29,11 +31,13 @@ func (m *Middlewares) Defaults() []func(next http.Handler) http.Handler {
 		m.RealIP,
 		m.StripSlashed,
 		m.CORS,
+		m.BrowserLang,
 	}
 }
 
 func InitMiddlewares(tools tools.Tools, cfg Config) *Middlewares {
 	return &Middlewares{
+		BrowserLang:  language.Middleware,
 		StripSlashed: middleware.StripSlashes,
 		Logger:       logger.NewRouterLogger(tools.Logger()),
 		OnlyJSON:     middleware.AllowContentType("application/json"),


### PR DESCRIPTION
The sort use the collate package in order to handle the specifics for each language. The sort ignore the case and the diacritics